### PR TITLE
BUG FIX -  Searching for conditions with text input (PARAM conditions)  

### DIFF
--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -201,7 +201,6 @@ def upload_files(app_config, hash_id, Files):
     if not os.path.exists(folder_path):
         os.mkdir(folder_path)
     for file in Files:
-        print(Files)
         if file.filename != '':
             file.save(os.path.join(folder_path, file.filename))
 

--- a/src/web/templates/conditions.html
+++ b/src/web/templates/conditions.html
@@ -68,7 +68,7 @@
                       {% set param_name = condition_single[0].split("&")[0] %}
 
                       {% if condition_single|length == 2 %}
-                        {% set param_value = "None" %}
+                        {% set param_value = "-" %}
                       {% elif condition_single|length == 3 %}
                         {% set param_value = condition_single[2] %}
                       {% endif %}
@@ -78,7 +78,11 @@
                           <label class="form-check-label" for="PARAM&condition&{{template_name}}&{{condition}}&{{condition_nested}}&{{param_name}}">
                             {{param_name}}
                           </label>
-                          <input type="text" required="required" name="PARAMVALUE&condition&{{template_name}}&{{condition}}&{{condition_nested}}&{{param_name}}" value={{param_value}} style="width: 50%;">
+                          {% if condition_single|length == 2 %}
+                            <input type="text" name="PARAMVALUE&condition&{{template_name}}&{{condition}}&{{condition_nested}}&{{param_name}}" style="width: 50%;">
+                          {% elif condition_single|length == 3 %}
+                            <input type="text" name="PARAMVALUE&condition&{{template_name}}&{{condition}}&{{condition_nested}}&{{param_name}}" value={{condition_single[2]}} style="width: 50%;">
+                          {% endif %}
                       </div>
 
                     {% else %}


### PR DESCRIPTION
- When searching for PARAM conditions, the author input was also considered as a part of the conditions name. It is now solved by removing that part from the conditions when searching in the database
- The text fields for the PARAM conditions is not required any more (They can be empty)
